### PR TITLE
Fix dimension spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ class YourUploader < CarrierWave::Uploader::Base
 end
 ```
 
-By default BombShelter sets maximum allowed dimensions to 4096x4096, but you can set your own ones by defining `max_pixel_dimentions` method:
+By default BombShelter sets maximum allowed dimensions to 4096x4096, but you can set your own ones by defining `max_pixel_dimensions` method:
 
 ```ruby
 class YourUploader < CarrierWave::Uploader::Base
   include CarrierWave::BombShelter
 
-  def max_pixel_dimentions
+  def max_pixel_dimensions
     [1024, 1024]
   end
 end

--- a/lib/carrierwave/bombshelter.rb
+++ b/lib/carrierwave/bombshelter.rb
@@ -14,24 +14,24 @@ module CarrierWave
     extend ActiveSupport::Concern
 
     included do
-      before :cache, :check_pixel_dimentions!
+      before :cache, :check_pixel_dimensions!
     end
 
-    def max_pixel_dimentions
+    def max_pixel_dimensions
       [4096, 4096]
     end
 
     private
 
-    def check_pixel_dimentions!(new_file)
+    def check_pixel_dimensions!(new_file)
       sizes = FastImage.size(new_file.path)
-      max_sizes = max_pixel_dimentions
+      max_sizes = max_pixel_dimensions
 
       return if !sizes || (sizes[0] <= max_sizes[0] && sizes[1] <= max_sizes[1])
 
       fail CarrierWave::IntegrityError,
            I18n.translate(
-             :'errors.messages.pixel_dimentions_error',
+             :'errors.messages.pixel_dimensions_error',
              x_size: max_sizes[0], y_size: max_sizes[1]
            )
     end

--- a/lib/locale/en.yml
+++ b/lib/locale/en.yml
@@ -1,4 +1,4 @@
 en:
   errors:
     messages:
-      pixel_dimentions_error: "Image size should be less than or equal to %{x_size}x%{y_size}"
+      pixel_dimensions_error: "Image size should be less than or equal to %{x_size}x%{y_size}"

--- a/lib/locale/ru.yml
+++ b/lib/locale/ru.yml
@@ -1,4 +1,4 @@
 ru:
   errors:
     messages:
-      pixel_dimentions_error: "Изображение не должно превышать размера %{x_size}x%{y_size}"
+      pixel_dimensions_error: "Изображение не должно превышать размера %{x_size}x%{y_size}"

--- a/test/bombshelter_test.rb
+++ b/test/bombshelter_test.rb
@@ -11,7 +11,7 @@ class TestBombShelter < Minitest::Test
       File.expand_path('../../tmp', __FILE__)
     end
 
-    def max_pixel_dimentions
+    def max_pixel_dimensions
       [5, 5]
     end
   end


### PR DESCRIPTION
Thanks for creating this gem!

This PR fixes the spelling of "dimension" because it is spelled with an `s` and not a `t` in english.
