### PR TITLE
Cast whitelisted image types to symbols

### DIFF
--- a/lib/carrierwave/bombshelter.rb
+++ b/lib/carrierwave/bombshelter.rb
@@ -39,7 +39,7 @@ module CarrierWave
     end
 
     def check_image_type!(image)
-      return if image.type && image_type_whitelist.include?(image.type)
+      return if image.type && image_type_whitelist.map(&:to_sym).include?(image.type)
       raise CarrierWave::IntegrityError,
             I18n.translate(:'errors.messages.unsupported_image_type')
     end

--- a/test/bombshelter_test.rb
+++ b/test/bombshelter_test.rb
@@ -15,6 +15,10 @@ class TestBombShelter < Minitest::Test
     def max_pixel_dimensions
       [5, 5]
     end
+
+    def image_type_whitelist
+      ["jpg", :jpeg, :gif, "png"]
+    end
   end
 
   def fixture_file(name)


### PR DESCRIPTION
Prevents from Unsupported image type error when whitelisted image types
were defined as strings
